### PR TITLE
Licenseの名前をblankに. 年月を最新に

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Tetsuya Mori
+Copyright (c) 2018 `<copyright holders>`
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## ISSUE 

- #24 

## 参考

- https://raw.githubusercontent.com/nevir/readable-licenses/master/markdown/MIT-LICENSE.md

## NOTE

デフォルトのコピーライトを修正しました...!